### PR TITLE
Fire an `addressfield:after` event immediately before returning

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,5 +196,8 @@ $.getJSON('path/to/above.json', function(config) {
 Looking for a full, compatible dataset of field configurations by country? You
 might be interested in v1.x of [addressfield.json](https://github.com/tableau-mkt/addressfield.json).
 
+## Events
+After calling jQuery.addressfield on a fieldset or other field/form wrapper the event named `addressfield:after` will be fired, immediately before returning. This can be useful when you need custom behavior right after addressfield does its thing.
+
 ## Contributing
 Check out the [Contributing guidelines](CONTRIBUTING.md)

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -87,6 +87,9 @@
     // Now ensure the fields are in their given order.
     $.fn.addressfield.orderFields.call($container, field_order);
 
+    // Trigger an addressfield:after event on the container.
+    $container.trigger('addressfield:after');
+
     return this;
   };
 

--- a/test/addressfield_test.js
+++ b/test/addressfield_test.js
@@ -782,4 +782,21 @@
     expect(2);
   });
 
+  test('check event fired', function() {
+    var config = {fields: [{'postalcode': {'label': 'Postcode', 'eg': '98103'}}]},
+        enabledFields = ['postalcode'],
+        fired = false;
+
+    // Bind an event listener for addressfield:after to the document element.
+    $(document).bind('addressfield:after', function () {
+      fired = true;
+    });
+
+    // Call the addressfield plugin and assert the correct effects.
+    this.address.addressfield(config, enabledFields);
+
+    ok(fired, 'should fire addressfield:after event');
+    expect(1);
+  });
+
 }(jQuery));


### PR DESCRIPTION
## What? Why?

After calling jQuery.addressfield on a fieldset or other field/form wrapper the event named `addressfield:after` will be fired, immediately before returning. This can be useful when you need custom behavior right after addressfield does its thing.
