### PR TITLE
Multiple fields and jQuery 1.7 ~ 1.10

### DIFF
--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -195,7 +195,7 @@
   $.fn.addressfield.binder = function(fieldMap, countryConfigMap) {
     var $container = this;
 
-    $(fieldMap.country).bind('change', function() {
+    $container.find(fieldMap.country).bind('change', function() {
       // Trigger the apply method with the country's data.
       $.fn.addressfield.apply.call($container, countryConfigMap[this.value], fieldMap);
     });


### PR DESCRIPTION
Applies to jQuery v1.7.x ~ v1.10.x. Resolves #41