### PR TITLE
Init countries

### DIFF
--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -193,15 +193,17 @@
   *
   *  A map of country codes to country names.
   */
-  $.fn.addressfield.initCountries = function(selector, countryMap){
-    var $container = this;
-    if($container.find(selector)[0].children.length === 0){
+  $.fn.addressfield.initCountries = function(selector, countryMap) {
+    var $container = this,
+        $countrySelect = $container.find(selector + ':not(:has(>option))');
+
+    if ($countrySelect.length) {
       $.each(countryMap, function(key, value) {
-         $container.find(selector)
-             .append($("<option></option>")
-             .attr("value",key)
-             .text(value.label)
-          );
+        $countrySelect
+          .append($('<option></option>')
+            .attr('value', key)
+            .text(value.label)
+        );
       });
     }
   };

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -59,12 +59,17 @@
         }, options);
 
     // If a path was given for a JSON resource, load the resource and execute.
+
     if (typeof configs.json === 'string') {
       $.ajax({
         dataType: "json",
         url: configs.json,
         async: configs.async,
         success: function (data) {
+          if($(configs.fields.country)[0].children.length === 0){
+            console.log('empty');
+            $.fn.addressfield.initCountries($.fn.addressfield.transform(data), configs.fields.country);
+          }
           $.fn.addressfield.binder.call($container, configs.fields, $.fn.addressfield.transform(data));
           $(configs.fields.country).change();
         }
@@ -179,6 +184,19 @@
   };
 
   /**
+  * Popualtes country dropdown with list of countries from provided json file if it is empty
+  */
+  $.fn.addressfield.initCountries = function(countryMap, selector){
+    $.each(countryMap, function(key, value) {
+       $(selector)
+           .append($("<option></option>")
+           .attr("value",key)
+           .text(value.label)
+        );
+    });
+  };
+
+  /**
    * Binds a handler to the country form field element, which applies postal
    * address form mutations to this form container based on the selected country
    * and given xNAL field map.
@@ -217,6 +235,7 @@
     }
 
     return countryMap;
+
   };
 
   /**

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -233,7 +233,6 @@
     }
 
     return countryMap;
-
   };
 
   /**

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -65,10 +65,9 @@
         url: configs.json,
         async: configs.async,
         success: function (data) {
-          if($(configs.fields.country)[0].children.length === 0){
-            $.fn.addressfield.initCountries($.fn.addressfield.transform(data), configs.fields.country);
-          }
-          $.fn.addressfield.binder.call($container, configs.fields, $.fn.addressfield.transform(data));
+          var transformedData = $.fn.addressfield.transform(data);
+          $.fn.addressfield.initCountries.call($container, configs.fields.country, transformedData);
+          $.fn.addressfield.binder.call($container, configs.fields, transformedData);
           $(configs.fields.country).change();
         }
       });
@@ -76,7 +75,9 @@
     }
     // In this case, a direct configuration has been provided inline.
     else if (typeof configs.json === 'object' && configs.json !== null) {
-      $.fn.addressfield.binder.call($container, configs.fields, $.fn.addressfield.transform(configs.json));
+      var transformedData = $.fn.addressfield.transform(configs.json);
+      $.fn.addressfield.initCountries.call($container, configs.fields.country, transformedData);
+      $.fn.addressfield.binder.call($container, configs.fields, transformedData);
       $(configs.fields.country).change();
       return $container;
     }
@@ -182,18 +183,28 @@
   };
 
   /**
-  * Popualtes country dropdown with list of countries from provided json file if it is empty
+  * Populates country dropdown with list of countries from provided json file if it is empty
+  *
+  *@param selector
+  *
+  *  Field identifying the country dropdown from user-configs.
+  *
+  *@param countryMap
+  *
+  *  A map of country codes to country names.
   */
-  $.fn.addressfield.initCountries = function(countryMap, selector){
-    $.each(countryMap, function(key, value) {
-       $(selector)
-           .append($("<option></option>")
-           .attr("value",key)
-           .text(value.label)
-        );
-    });
+  $.fn.addressfield.initCountries = function(selector, countryMap){
+    var $container = this;
+    if($container.find(selector)[0].children.length === 0){
+      $.each(countryMap, function(key, value) {
+         $container.find(selector)
+             .append($("<option></option>")
+             .attr("value",key)
+             .text(value.label)
+          );
+      });
+    }
   };
-
   /**
    * Binds a handler to the country form field element, which applies postal
    * address form mutations to this form container based on the selected country

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -59,7 +59,6 @@
         }, options);
 
     // If a path was given for a JSON resource, load the resource and execute.
-
     if (typeof configs.json === 'string') {
       $.ajax({
         dataType: "json",

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -67,7 +67,6 @@
         async: configs.async,
         success: function (data) {
           if($(configs.fields.country)[0].children.length === 0){
-            console.log('empty');
             $.fn.addressfield.initCountries($.fn.addressfield.transform(data), configs.fields.country);
           }
           $.fn.addressfield.binder.call($container, configs.fields, $.fn.addressfield.transform(data));


### PR DESCRIPTION

Okay, updated according to feedback:

 - Moved check for empty country field to initCountires()
 - Added check for initCountries() when the configs.json are an object rather than a URL.
 - TransformedData is now saved to a variable and re-used rather than transforming multiple times.
 - Passing Container properly to initCountries now to limit selection to the container element.

I have tested and verified that this works as expected (on Chrome, OSX):

 - When countries are provided as a separate JSON file and the dropdown is unpopulated, the country populated from the JSON File by initCountries().
 - When the countries are provided as an object and the dropdown is unpopulated, the countries are populated from the object by initCountries().
 - In both cases, when the country dropdown is populated with select tags initCountries() does not populate the dropdown.

I was not able to implement the selector as you suggested, but I do think it would be more readable and match the code style of the rest of the file better, so if someone else is able to get it working I would like to see what I was doing wrong. Also, what other testing would you suggest?