### PR TITLE
Simplify field reordering, preserve event handlers on unchanged DOM.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
       },
       all: {
         options: {
-          urls: ['1.3.2', '1.4.4', '1.5.2', '1.6.4', '1.7.2', '1.8.3', '1.9.1', '1.10.2', '1.11.1', 'git1', '2.0.3', '2.1.0', '2.1.1', 'git2'].map(function(version) {
+          urls: ['1.4.4', '1.5.2', '1.6.4', '1.7.2', '1.8.3', '1.9.1', '1.10.2', '1.11.1', 'git1', '2.0.3', '2.1.0', '2.1.1', 'git2'].map(function(version) {
             return 'test/addressfield.html?jquery=' + version;
           })
         }

--- a/addressfield.jquery.json
+++ b/addressfield.jquery.json
@@ -20,7 +20,7 @@
     }
   ],
   "dependencies": {
-    "jquery": ">=1.3.2"
+    "jquery": ">=1.4.4"
   },
   "keywords": [
     "postal",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   "description": "The simple, configurable, dynamic postal address form plugin.",
   "main": "dist/jquery.addressfield.js",
   "dependencies" : {
-    "jquery": ">=1.3.2",
+    "jquery": ">=1.4.4",
     "addressfield.json": "~1.1"
   },
   "devDependencies": {

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -343,8 +343,7 @@
       if (config.hasOwnProperty('format')) {
         // Create the validation method.
         $.validator.addMethod(methodName, function (value) {
-          // @todo Drop jQuery 1.3 support. No need for .toString() call.
-          return new RegExp(config.format).test($.trim(value.toString()));
+          return new RegExp(config.format).test($.trim(value));
         }, message);
 
         // Apply the rule.
@@ -390,13 +389,7 @@
         elementName = $this.attr('id'),
         $label = $('label[for="' + elementName + '"]') || $this.prev('label');
 
-    // @todo drop support for jQuery 1.3, just use .has()
-    if (typeof $.fn.has === 'function') {
-      return $this.parents().has($label).first();
-    }
-    else {
-      return $this.parents().find(':has(label):has(#' + elementName + '):last');
-    }
+    return $this.parents().has($label).first();
   };
 
   /**
@@ -425,36 +418,17 @@
    * order array is itself an array.
    */
   $.fn.addressfield.orderFields = function(order) {
-    var length = order.length,
-        i,
-        $element;
+    var $self = $(this),
+        $orderedContainers = $();
 
-    // Iterate through the fields to be ordered.
-    for (i = 0; i < length; ++i) {
-      if (i in order) {
-        // Save off the element container over its class selector in order.
-        $element = $.fn.addressfield.container.call(this.find(order[i]));
-        order[i] = {
-          'element': $element.clone(),
-          'selector': order[i],
-          'value': $(this).find(order[i]).val()
-        };
+    // Form a jQuery object with container elements in the correct order.
+    $.each(order, function (index, selector) {
+      var $container = $.fn.addressfield.container.call($self.find(selector));
+      $orderedContainers.push($container[0]);
+    });
 
-        // Remove the original element from the page.
-        $element.remove();
-      }
-    }
-
-    // Elements have been saved off in order and removed. Now, add them back in
-    // the correct order.
-    for (i = 0; i < length; ++i) {
-      if (i in order) {
-        $element = $(this).append(order[i].element);
-
-        // The clone process doesn't seem to copy input values; apply that here.
-        $element.find(order[i]['selector']).val(order[i].value).change();
-      }
-    }
+    // Re-append to parent in the correct order.
+    $orderedContainers.detach().appendTo($self);
   };
 
 }(jQuery));

--- a/test/addressfield_test.js
+++ b/test/addressfield_test.js
@@ -434,22 +434,16 @@
         },
         oldOrder = [],
         newOrder = [],
-        mockCloneData = [],
-        mockRemoveData = [],
-        oldClone = $.fn.clone,
-        oldRemove = $.fn.remove,
+        mockDetachData = [],
+        oldDetach = $.fn.detach,
         $wrapper = this.address.find('.locality');
 
-    // Override the core clone method.
-    $.fn.clone = function() {
-      mockCloneData.push('.' + $(this).find('input, select').attr('class'));
-      return oldClone.call(this);
-    };
-
-    // Override the core remove method.
-    $.fn.remove = function() {
-      mockRemoveData.push('.' + $(this).find('input, select').attr('class'));
-      return oldRemove.call(this);
+    // Override the core detach method.
+    $.fn.detach = function() {
+      mockDetachData = $.map(this, function (element) {
+        return '.' + $(element).find('input, select').attr('class');
+      });
+      return oldDetach.call(this);
     };
 
     // Get the existing order of the locality fields.
@@ -472,12 +466,10 @@
     });
 
     deepEqual(newOrder, expectedOrder, 'Order of fields updated as expected.');
-    equal(mockCloneData.length, expectedOrder.length, 'Clone method called the correct number of times.');
-    deepEqual(mockCloneData, expectedOrder, 'Clone method called for each field in the expected order.');
-    equal(mockRemoveData.length, expectedOrder.length, 'Remove method called the correct number of times.');
-    deepEqual(mockRemoveData, expectedOrder, 'Remove method called for each field in the expected order.');
+    equal(mockDetachData.length, expectedOrder.length, 'Detach method called with the correct number of elements.');
+    deepEqual(mockDetachData, expectedOrder, 'Detach method called for each field in the expected order.');
 
-    expect(5 + Object.keys(expectedVals).length);
+    expect(3 + Object.keys(expectedVals).length);
   });
 
   module('jQuery#addressfield plugin behavior', {


### PR DESCRIPTION
- Simplify field reordering, preserve event handlers on unchanged DOM.
- Drop jQuery 1.3 support.
- Suggest bumping version to 2.0.0.