### PR TITLE
Init countries

### DIFF
--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -61,7 +61,8 @@
           async: true,
           // @deprecated Support for manual, synchronous, external control.
           defs: {fields: {}}
-        }, options);
+        }, options),
+        transformedData;
 
     // If a path was given for a JSON resource, load the resource and execute.
     if (typeof configs.json === 'string') {
@@ -70,7 +71,10 @@
         url: configs.json,
         async: configs.async,
         success: function (data) {
-          $.fn.addressfield.binder.call($container, configs.fields, $.fn.addressfield.transform(data));
+          transformedData = $.fn.addressfield.transform(data);
+
+          $.fn.addressfield.initCountries.call($container, configs.fields.country, transformedData);
+          $.fn.addressfield.binder.call($container, configs.fields, transformedData);
           $(configs.fields.country).change();
         }
       });
@@ -78,7 +82,10 @@
     }
     // In this case, a direct configuration has been provided inline.
     else if (typeof configs.json === 'object' && configs.json !== null) {
-      $.fn.addressfield.binder.call($container, configs.fields, $.fn.addressfield.transform(configs.json));
+      transformedData = $.fn.addressfield.transform(configs.json);
+
+      $.fn.addressfield.initCountries.call($container, configs.fields.country, transformedData);
+      $.fn.addressfield.binder.call($container, configs.fields, transformedData);
       $(configs.fields.country).change();
       return $container;
     }
@@ -181,6 +188,31 @@
     $container.trigger('addressfield:after', {config: config, fieldMap: fieldMap});
 
     return this;
+  };
+
+  /**
+  * Populates country dropdown with list of countries from provided json file if it is empty.
+  *
+  * @param selector
+  *   Field identifying the country dropdown from user-configs.
+  *
+  * @param countryMap
+  *   A map of country codes to country names.
+  */
+  $.fn.addressfield.initCountries = function(selector, countryMap) {
+    var $container = this,
+        $countrySelect = $container.find(selector + ':not(:has(>option))');
+
+    if (!$countrySelect.length) {
+      return;
+    }
+
+    $.each(countryMap, function(key, value) {
+      $countrySelect.append($('<option></option>')
+        .attr('value', key)
+        .text(value.label)
+      );
+    });
   };
 
   /**

--- a/test/addressfield-test.js
+++ b/test/addressfield-test.js
@@ -256,6 +256,7 @@
   test('empty country population', function() {
     var $cloneAddress = this.address.clone(),
         $emptyCountry = $cloneAddress.find('.country'),
+        oldAjax = $.ajax,
         mockJsonData = {
           "label": "Country",
           "options": [
@@ -272,9 +273,11 @@
               "iso": "JA"
             }
           ]
-        };
+        },
+        expectedResponseData = $.extend(true, {}, mockJsonData);
 
-    // Init with mock data.
+    // Init with mock inline JSON data. This should be a no-op because the <select> is already
+    // populated with options.
     $cloneAddress.addressfield({json: mockJsonData, fields: {country: '.country'}});
 
     strictEqual($cloneAddress.find('.country option').length, $(this.address).find('.country option').length, 'Same number of options exist as initial country select element.');
@@ -282,7 +285,7 @@
     // Now empty out the cloned <select>.
     $emptyCountry.find('option').remove();
 
-    // Init again with mock data.
+    // Init again with mock inline JSON data.
     $cloneAddress.addressfield({json: mockJsonData, fields: {country: '.country'}});
 
     strictEqual($emptyCountry.find('option').length, mockJsonData.options.length, 'Correct number of options appended to country select element.');
@@ -293,7 +296,44 @@
       strictEqual($emptyCountry.find('option[value="' + value.iso + '"]').text(), mockJsonData.options[optionPos]['label'], 'Should add proper label for each value');
     });
 
-    expect(8);
+    // Test against mock ajax retrieved data.
+
+    // First. Push another option into the mock ajax repsponse to differentiate it from the mock JSON string.
+    expectedResponseData.options.push({
+      "label": "Germany",
+      "iso": "DE"
+    });
+
+    // Mock an ajax request.
+    $.ajax = function(options) {
+      options.success(expectedResponseData);
+      // Override so any real AJAX results in a no-op.
+      options.success = function() {};
+      return oldAjax(options);
+    };
+
+    // Now empty out the cloned <select> again.
+    $emptyCountry.find('option').remove();
+
+    // Init a synchronous mock ajax request.
+    $cloneAddress.addressfield({
+      json: '/foo/bar/baz.json',
+      fields: {country: '.country'},
+      async: false
+    });
+
+    strictEqual($emptyCountry.find('option').length, expectedResponseData.options.length, 'Correct number of options appended to country select element via ajax request.');
+
+    // Check that the new values match up.
+    $.each(expectedResponseData.options, function(optionPos, value) {
+      strictEqual($emptyCountry.find('option[value="' + value.iso + '"]').length, 1, 'Should add new option');
+      strictEqual($emptyCountry.find('option[value="' + value.iso + '"]').text(), expectedResponseData.options[optionPos]['label'], 'Should add proper label for each value');
+    });
+
+    // Reset methods.
+    $.ajax = oldAjax;
+
+    expect(17);
   });
 
   test('default field hide', function() {

--- a/test/addressfield-test.js
+++ b/test/addressfield-test.js
@@ -253,6 +253,49 @@
     expect(6 + oldOptions.length - 1 + Object.keys(options).length * 2);
   });
 
+  test('empty country population', function() {
+    var $cloneAddress = this.address.clone(),
+        $emptyCountry = $cloneAddress.find('.country'),
+        mockJsonData = {
+          "label": "Country",
+          "options": [
+            {
+              "label": "United States",
+              "iso": "US"
+            },
+            {
+              "label": "Canada",
+              "iso": "CA"
+            },
+            {
+              "label": "Japan",
+              "iso": "JA"
+            }
+          ]
+        };
+
+    // Init with mock data.
+    $cloneAddress.addressfield({json: mockJsonData, fields: {country: '.country'}});
+
+    strictEqual($cloneAddress.find('.country option').length, $(this.address).find('.country option').length, 'Same number of options exist as initial country select element.');
+
+    // Now empty out the cloned <select>.
+    $emptyCountry.find('option').remove();
+
+    // Init again with mock data.
+    $cloneAddress.addressfield({json: mockJsonData, fields: {country: '.country'}});
+
+    strictEqual($emptyCountry.find('option').length, mockJsonData.options.length, 'Correct number of options appended to country select element.');
+
+    // Check that the new values match up.
+    $.each(mockJsonData.options, function(optionPos, value) {
+      strictEqual($emptyCountry.find('option[value="' + value.iso + '"]').length, 1, 'Should add new option');
+      strictEqual($emptyCountry.find('option[value="' + value.iso + '"]').text(), mockJsonData.options[optionPos]['label'], 'Should add proper label for each value');
+    });
+
+    expect(8);
+  });
+
   test('default field hide', function() {
     // Set a value on the postal code field.
     this.postalcode.val('foo');


### PR DESCRIPTION
## What/Why
Initializing countries for an empty `<select>` based on the code that @CommandLineDesign provided in #47.

- Slight modifications around variable declaration location
- Exit fast pattern in the `initCountries()` method when testing against empty country `<select>`
- Adds QUnit tests against the behavior