### PR TITLE
Fixes issue #58 by reading for data attr for default country

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,6 +13,8 @@ To ensure the plugin is able to do its thing, please make sure of the following:
   code) are themselves wrapped within a container and that you specify a
   selector for that container. This is necessary because some countries display
   a locality field _set_ with different weight with respect to other fields.
+- Optionally you can specify which country is selected by default. Just add a
+  data attribute to the country select.
 
 Here's example markup that encompasses the above recommendations:
 
@@ -21,7 +23,7 @@ Here's example markup that encompasses the above recommendations:
   <div class="field-wrapper">
     <div class="field-wrapper">
       <label for="country">Country</label>
-      <select id="country"></select>
+      <select id="country" data-country-selected="US"></select>
     </div>
   </div>
   <div id="locality-fields">

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -202,7 +202,7 @@
   $.fn.addressfield.initCountries = function(selector, countryMap) {
     var $container = this,
         $countrySelect = $container.find(selector + ':not(:has(>option))'),
-		defaultCountry = $countrySelect.data().countrySelected;
+		    defaultCountry = $countrySelect.data().countrySelected;
 
     if (!$countrySelect.length) {
       return;

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -201,17 +201,27 @@
   */
   $.fn.addressfield.initCountries = function(selector, countryMap) {
     var $container = this,
-        $countrySelect = $container.find(selector + ':not(:has(>option))');
+        $countrySelect = $container.find(selector + ':not(:has(>option))'),
+		defaultCountry = $countrySelect.data().countrySelected;
 
     if (!$countrySelect.length) {
       return;
     }
 
     $.each(countryMap, function(key, value) {
-      $countrySelect.append($('<option></option>')
-        .attr('value', key)
-        .text(value.label)
-      );
+      if (typeof defaultCountry != 'undefined' &&
+          key.toLowerCase() === defaultCountry.toLowerCase()) {
+        $countrySelect.append($('<option></option>')
+          .attr('value', key)
+          .attr('selected', 'selected')
+          .text(value.label)
+        );
+      } else {
+        $countrySelect.append($('<option></option>')
+          .attr('value', key)
+          .text(value.label)
+        );
+      }
     });
   };
 

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -202,10 +202,12 @@
   $.fn.addressfield.initCountries = function(selector, countryMap) {
     var $container = this,
         $countrySelect = $container.find(selector + ':not(:has(>option))'),
-        defaultCountry = $countrySelect.data().countrySelected;
+        defaultCountry;
 
     if (!$countrySelect.length) {
       return;
+    } else {
+      defaultCountry = $countrySelect.data().countrySelected;
     }
 
     $.each(countryMap, function(key, value) {

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -202,14 +202,14 @@
   $.fn.addressfield.initCountries = function(selector, countryMap) {
     var $container = this,
         $countrySelect = $container.find(selector + ':not(:has(>option))'),
-		    defaultCountry = $countrySelect.data().countrySelected;
+        defaultCountry = $countrySelect.data().countrySelected;
 
     if (!$countrySelect.length) {
       return;
     }
 
     $.each(countryMap, function(key, value) {
-      if (typeof defaultCountry != 'undefined' &&
+      if (typeof defaultCountry !== 'undefined' &&
           key.toLowerCase() === defaultCountry.toLowerCase()) {
         $countrySelect.append($('<option></option>')
           .attr('value', key)

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -206,8 +206,9 @@
 
     if (!$countrySelect.length) {
       return;
-    } else {
-      defaultCountry = $countrySelect.attr("data-country-selected");
+    }
+    else {
+      defaultCountry = $countrySelect.attr('data-country-selected');
     }
 
     $.each(countryMap, function(key, value) {
@@ -218,7 +219,8 @@
           .attr('selected', 'selected')
           .text(value.label)
         );
-      } else {
+      }
+      else {
         $countrySelect.append($('<option></option>')
           .attr('value', key)
           .text(value.label)

--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -207,7 +207,7 @@
     if (!$countrySelect.length) {
       return;
     } else {
-      defaultCountry = $countrySelect.data().countrySelected;
+      defaultCountry = $countrySelect.attr("data-country-selected");
     }
 
     $.each(countryMap, function(key, value) {

--- a/test/addressfield-test.js
+++ b/test/addressfield-test.js
@@ -336,6 +336,37 @@
     expect(17);
   });
 
+  test('select a default country', function() {
+    var $cloneAddress = this.address.clone(),
+        $emptyCountry = $cloneAddress.find('.country'),
+        mockJsonData = {
+          "label": "Country",
+          "options": [
+            {
+              "label": "United States",
+              "iso": "US"
+            },
+            {
+              "label": "Canada",
+              "iso": "CA"
+            },
+            {
+              "label": "Japan",
+              "iso": "JA"
+            }
+          ]
+        };
+
+    $emptyCountry.attr("data-country-selected", "US");
+
+    // Init with mock inline JSON data. This should be a no-op because the <select> is already
+    // populated with options.
+    $cloneAddress.addressfield({json: mockJsonData, fields: {country: '.country'}});
+
+    // Check the country is set to US
+    strictEqual($emptyCountry.val(), 'US', 'Expected country to be set to US');
+  });
+
   test('default field hide', function() {
     // Set a value on the postal code field.
     this.postalcode.val('foo');

--- a/test/addressfield-test.js
+++ b/test/addressfield-test.js
@@ -357,7 +357,44 @@
           ]
         };
 
-    $emptyCountry.attr("data-country-selected", "US");
+    // Remove existing countries and set the default attr to CA
+    $emptyCountry.find('option').remove().end();
+    $emptyCountry.attr("data-country-selected", "CA");
+
+
+    // Init with mock inline JSON data. This should be a no-op because the <select> is already
+    // populated with options.
+    $cloneAddress.addressfield({json: mockJsonData, fields: {country: '.country'}});
+
+    // Check the country is set to US
+    strictEqual($emptyCountry.val(), 'CA', 'Expected country to be set to CA');
+  });
+
+  test('select an invalid default country', function() {
+    var $cloneAddress = this.address.clone(),
+        $emptyCountry = $cloneAddress.find('.country'),
+        mockJsonData = {
+          "label": "Country",
+          "options": [
+            {
+              "label": "United States",
+              "iso": "US"
+            },
+            {
+              "label": "Canada",
+              "iso": "CA"
+            },
+            {
+              "label": "Japan",
+              "iso": "JA"
+            }
+          ]
+        };
+
+    // Remove existing countries and set the default attr to CA
+    $emptyCountry.find('option').remove().end();
+    $emptyCountry.attr("data-country-selected", "CAA");
+
 
     // Init with mock inline JSON data. This should be a no-op because the <select> is already
     // populated with options.


### PR DESCRIPTION
Allows a developer to add a data attribute with the country they want to be selected by default

`<select class="country" id="address-country" name="address[country]" data-country-selected="US"></select>`