### PR TITLE
Make validation tests case insensitive.

### DIFF
--- a/src/jquery.addressfield.js
+++ b/src/jquery.addressfield.js
@@ -395,7 +395,8 @@
         // Create the validation method.
         $.validator.addMethod(methodName, function (value) {
           // @todo Drop jQuery 1.3 support. No need for .toString() call.
-          return new RegExp(config.format).test($.trim(value.toString()));
+          // Make validation case insenstitve.
+          return new RegExp(config.format, 'i').test($.trim(value.toString()));
         }, message);
 
         // Apply the rule.

--- a/test/addressfield-test.js
+++ b/test/addressfield-test.js
@@ -49,6 +49,7 @@
   test('default example placeholder', function() {
     var postExamplesExpecteds = {
           "98103": "e.g. 98103",
+          "a1c 5M2": "e.g. a1c 5M2",
           "": ""
         },
         example;


### PR DESCRIPTION
Allow for upper/lower/mixed case in any field when using jquery.validate.